### PR TITLE
Ruby 2.2 support for webauthn-ruby 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'cose', git: 'https://github.com/aptible/cose-ruby', branch: 'aptible'
+
 # Specify your gem's dependencies in webauthn.gemspec
 gemspec

--- a/lib/android_safetynet/attestation_response.rb
+++ b/lib/android_safetynet/attestation_response.rb
@@ -76,7 +76,7 @@ module AndroidSafetynet
     end
 
     def valid_attestation_domain?
-      common_name = leaf_certificate&.subject&.to_a&.assoc('CN')
+      common_name = leaf_certificate.try(:subject).try(:to_a).assoc('CN')
 
       if common_name
         common_name[1] == VALID_SUBJECT_HOSTNAME

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -27,7 +27,7 @@ module WebAuthn
       end
 
       def attestation_certificate
-        certificates&.first
+        certificates.try(:first)
       end
 
       def certificate_chain
@@ -41,7 +41,7 @@ module WebAuthn
       attr_reader :statement
 
       def matching_aaguid?(attested_credential_data_aaguid)
-        extension = attestation_certificate&.extensions&.detect { |ext| ext.oid == AAGUID_EXTENSION_OID }
+        extension = attestation_certificate.try(:extensions).try(:detect, { |ext| ext.oid == AAGUID_EXTENSION_OID })
         if extension
           # `extension.value` mangles data into ASCII, so we must manually compare bytes
           # see https://github.com/ruby/openssl/pull/234
@@ -53,7 +53,7 @@ module WebAuthn
       end
 
       def certificates
-        @certificates ||= raw_certificates&.map do |raw_certificate|
+        @certificates ||= raw_certificates.map do |raw_certificate|
           OpenSSL::X509::Certificate.new(raw_certificate)
         end
       end
@@ -75,7 +75,7 @@ module WebAuthn
       end
 
       def attestation_trust_path
-        if certificates&.any?
+        if certificates.try(:any?)
           certificates
         end
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -41,7 +41,7 @@ module WebAuthn
       attr_reader :statement
 
       def matching_aaguid?(attested_credential_data_aaguid)
-        extension = attestation_certificate.try(:extensions).try(:detect, { |ext| ext.oid == AAGUID_EXTENSION_OID })
+        extension = attestation_certificate.try(:extensions).detect { |ext| ext.oid == AAGUID_EXTENSION_OID }
         if extension
           # `extension.value` mangles data into ASCII, so we must manually compare bytes
           # see https://github.com/ruby/openssl/pull/234

--- a/lib/webauthn/attestation_statement/packed.rb
+++ b/lib/webauthn/attestation_statement/packed.rb
@@ -54,7 +54,7 @@ module WebAuthn
       end
 
       def valid_ec_public_keys?(credential)
-        (certificates&.map(&:public_key) || [credential.public_key_object])
+        (certificates.map(&:public_key) || [credential.public_key_object])
           .select { |pkey| pkey.is_a?(OpenSSL::PKey::EC) }
           .all? { |pkey| pkey.check_key }
       end
@@ -66,8 +66,8 @@ module WebAuthn
 
           attestation_certificate.version == 2 &&
             certificate_in_use?(attestation_certificate) &&
-            subject.assoc('OU')&.at(1) == "Authenticator Attestation" &&
-            attestation_certificate.extensions.find { |ext| ext.oid == 'basicConstraints' }&.value == 'CA:FALSE'
+            subject.assoc('OU').try(:at, 1) == "Authenticator Attestation" &&
+            attestation_certificate.extensions.find { |ext| ext.oid == 'basicConstraints' }.try(:value) == 'CA:FALSE'
         else
           true
         end
@@ -82,7 +82,7 @@ module WebAuthn
       def valid_signature?(authenticator_data, client_data_hash)
         signature_verifier = WebAuthn::SignatureVerifier.new(
           algorithm,
-          attestation_certificate&.public_key || authenticator_data.credential.public_key_object
+          attestation_certificate.try(:public_key) || authenticator_data.credential.public_key_object
         )
 
         signature_verifier.verify(signature, authenticator_data.data + client_data_hash)

--- a/lib/webauthn/attestation_statement/tpm.rb
+++ b/lib/webauthn/attestation_statement/tpm.rb
@@ -56,13 +56,13 @@ module WebAuthn
           attestation_certificate.subject.eql?(CERTIFICATE_EMPTY_NAME) &&
           valid_subject_alternative_name? &&
           certificate_in_use?(attestation_certificate) &&
-          extensions.find { |ext| ext.oid == 'basicConstraints' }&.value == "CA:FALSE" &&
-          extensions.find { |ext| ext.oid == "extendedKeyUsage" }&.value == OID_TCG_KP_AIK_CERTIFICATE
+          extensions.find { |ext| ext.oid == 'basicConstraints' }.try(:value) == "CA:FALSE" &&
+          extensions.find { |ext| ext.oid == "extendedKeyUsage" }.try(:value) == OID_TCG_KP_AIK_CERTIFICATE
       end
 
       def valid_subject_alternative_name?
         extension = attestation_certificate.extensions.detect { |ext| ext.oid == "subjectAltName" }
-        return unless extension&.critical?
+        return unless extension.try(:critical?)
 
         san_asn1 = OpenSSL::ASN1.decode(extension).find do |val|
           val.tag_class == :UNIVERSAL && val.tag == OpenSSL::ASN1::OCTET_STRING

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -74,7 +74,7 @@ module WebAuthn
     end
 
     def attestation_certificate_key
-      raw_subject_key_identifier(attestation_statement.attestation_certificate)&.unpack("H*")&.[](0)
+      raw_subject_key_identifier(attestation_statement.attestation_certificate).try(:unpack, "H*").[](0)
     end
 
     private

--- a/lib/webauthn/encoder.rb
+++ b/lib/webauthn/encoder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "base64url"
 
 module WebAuthn
   def self.standard_encoder
@@ -22,7 +23,7 @@ module WebAuthn
       when :base64
         Base64.strict_encode64(data)
       when :base64url
-        Base64.urlsafe_encode64(data, padding: false)
+        Base64URL.encode(data)
       when nil, false
         data
       else
@@ -35,7 +36,7 @@ module WebAuthn
       when :base64
         Base64.strict_decode64(data)
       when :base64url
-        Base64.urlsafe_decode64(data)
+        Base64URL.decode(data)
       when nil, false
         data
       else

--- a/lib/webauthn/fake_authenticator.rb
+++ b/lib/webauthn/fake_authenticator.rb
@@ -83,7 +83,13 @@ module WebAuthn
     attr_reader :credentials
 
     def new_credential
-      [SecureRandom.random_bytes(16), OpenSSL::PKey::EC.new("prime256v1").generate_key, 0]
+      key = OpenSSL::PKey::EC.new('prime256v1').tap do |ec|
+        ec.generate_key
+        # https://bugs.ruby-lang.org/issues/8177
+        ec.define_singleton_method(:private?) { private_key? }
+        ec.define_singleton_method(:public?) { public_key? }
+      end
+      [SecureRandom.random_bytes(16), key, 0]
     end
 
     def hashed(target)

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -15,7 +15,12 @@ module WebAuthn
         rp_id_hash:,
         credential: {
           id: SecureRandom.random_bytes(16),
-          public_key: OpenSSL::PKey::EC.new("prime256v1").generate_key.public_key
+          public_key: OpenSSL::PKey::EC.new('prime256v1').tap do |ec|
+            ec.generate_key
+            # https://bugs.ruby-lang.org/issues/8177
+            ec.define_singleton_method(:private?) { private_key? }
+            ec.define_singleton_method(:public?) { public_key? }
+          end.public_key
         },
         sign_count: 0,
         user_present: true,

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -30,7 +30,7 @@ module WebAuthn
     end
 
     def sign_count
-      response&.authenticator_data&.sign_count
+      response.try(:authenticator_data).try(:sign_count)
     end
 
     private

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -24,7 +24,7 @@ module WebAuthn
     end
 
     def raw_public_key
-      response&.authenticator_data&.credential&.public_key
+      response.try(:authenticator_data).try(:credential).try(:public_key)
     end
   end
 end

--- a/lib/webauthn/u2f_migrator.rb
+++ b/lib/webauthn/u2f_migrator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'base64url'
 require 'webauthn/fake_client'
 require 'webauthn/attestation_statement/fido_u2f'
 
@@ -47,7 +48,7 @@ module WebAuthn
     # https://fidoalliance.org/specs/fido-v2.0-rd-20180702/fido-client-to-authenticator-protocol-v2.0-rd-20180702.html#u2f-authenticatorMakeCredential-interoperability
     # Let credentialId be a credentialIdLength byte array initialized with CTAP1/U2F response key handle bytes.
     def credential_id
-      Base64.urlsafe_decode64(@key_handle)
+      Base64URL.decode(@key_handle)
     end
 
     # Let x9encodedUserPublicKey be the user public key returned in the U2F registration response message [U2FRawMsgs].

--- a/spec/conformance/mds_finder.rb
+++ b/spec/conformance/mds_finder.rb
@@ -18,7 +18,7 @@ class MDSFinder
         fido_metadata_store.fetch_statement(attestation_certificate_key_id: attestation_certificate_key_id)
       end
 
-    metadata_statement&.attestation_root_certificates || []
+    metadata_statement.try(:attestation_root_certificates) || []
   end
 
   private

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "awrence", "~> 1.1"
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
-  spec.add_dependency "cose", "~> 0.8.0"
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
   spec.add_dependency "securecompare", "~> 1.0"
   spec.add_dependency "base64url", "~> 1.0.1"

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "awrence", "~> 1.1"
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
-  spec.add_dependency "cose", "~> 0.10.0"
+  spec.add_dependency "cose", "~> 0.8.0"
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
   spec.add_dependency "openssl", "~> 2.0"
   spec.add_dependency "securecompare", "~> 1.0"

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.2"
 
   spec.add_dependency "awrence", "~> 1.1"
   spec.add_dependency "bindata", "~> 2.4"
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
   spec.add_dependency "openssl", "~> 2.0"
   spec.add_dependency "securecompare", "~> 1.0"
+  spec.add_dependency "base64url", "~> 1.0.1"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 0.8.0"
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
-  spec.add_dependency "openssl", "~> 2.0"
   spec.add_dependency "securecompare", "~> 1.0"
   spec.add_dependency "base64url", "~> 1.0.1"
 


### PR DESCRIPTION
This PR adds support for ruby2.2 for the webauthn-ruby gem.