### PR TITLE
Travis -> GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: build
+
+on:  
+  push:
+    branches:
+      - aptible-v2
+  pull_request:
+    barnches:
+      - aptible-v2
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.3'
+        gemfile:
+          - cose_head
+          - openssl_head
+          - openssl_2_1
+          - openssl_2_0
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake


### PR DESCRIPTION
Ultimately we should unfork ourselves. We made [some changes](https://github.com/cedarcode/webauthn-ruby/compare/master...aptible:webauthn-ruby:aptible-v2) in the name of supporting ruby 2.2(?), which causes rubocop to fail, and even undoing that:

* The existing tests ALL fail in travis (bundler version issue)
* My attempt to migrate tests to GHA also all fail for similar core issues.

Upstream has already moved to GHA, anyways...